### PR TITLE
Backend Shimomura 「omniauth_callbacksコントローラーの動作確認用コードを本実装用に変更」

### DIFF
--- a/backend/app/controllers/api/v1/omniauth_callbacks_controller.rb
+++ b/backend/app/controllers/api/v1/omniauth_callbacks_controller.rb
@@ -22,13 +22,6 @@ class Api::V1::OmniauthCallbacksController < DeviseTokenAuth::OmniauthCallbacksC
     #   render json: { message: "failed to login" }, status: 500
     # end
 
-    # @resource.save!
-
-    # yield @resource if block_given?
-
-    # render_data_or_redirect('deliverCredentials', @auth_params.as_json, @resource.as_json)
-
-
     if @resource.save!
       update_auth_header
       yield @resource if block_given?


### PR DESCRIPTION
## 概要
* omniauth_callbacksコントローラーの動作確認用コードを本実装用に変更
* 新規登録時→https://localhost:3000/sign_up、ログイン時→https://localhost:3000にリダイレクト
* herokuデプロイ済み

## ToDo
フロントのURLが変わった際、変更が必要です。